### PR TITLE
feat: add openai realtime voice command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ _This command is still a work in progress. We're working with the Slack team to 
 
 #### Environment Setup
 1. Add your `AI_GATEWAY_API_KEY` to your `.env` file. You can get one [here](https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai%2Fapi-keys%3Futm_source%3Dai_gateway_landing_page&title=Get+an+API+Key)
-2. _(Optional)_ You can also use your `VERCEL_OIDC_TOKEN ` to authenticate with the Vercel AI Gateway. More info [here](https://vercel.com/docs/oidc#in-local-development)
+2. Add your `OPENAI_API_KEY` to enable voice connections through the OpenAI Realtime API.
+3. _(Optional)_ You can also use your `VERCEL_OIDC_TOKEN ` to authenticate with the Vercel AI Gateway. More info [here](https://vercel.com/docs/oidc#in-local-development)
 
 #### Prepare for Local Development
 
@@ -56,6 +57,7 @@ _This command is still a work in progress. We're working with the Slack team to 
 6. Start your local server with automatic tunneling using the `pnpm dev:tunnel` command. You can also use the generic `slack run` command if you do not want automatic tunneling and manifest updates. If prompted, select the workspace you'd like to grant access to. Select `yes` when asked _Update app settings with changes to the local manifest?_
 
 7. Open your Slack workspace and add your new Slack Agent to a channel. Your Slack Agent should respond whenever it's tagged in a message or sent a DM
+8. Use the `/voice` slash command to create a voice session powered by the OpenAI Realtime API
 
 ## Deploy to Vercel
 1. Create a new Vercel project [here](https://www.vercel.com/new) or select _Add new..._ and _project_ from the Vercel dashboard

--- a/manifest.json
+++ b/manifest.json
@@ -26,6 +26,12 @@
         "url": "https://2803e0a4d693.ngrok.app/api/events",
         "description": "Runs a sample command",
         "should_escape": false
+      },
+      {
+        "command": "/voice",
+        "url": "https://2803e0a4d693.ngrok.app/api/events",
+        "description": "Start a voice session with the AI agent",
+        "should_escape": false
       }
     ],
     "assistant_view": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@slack/web-api": "^7.10.0",
     "@vercel/slack-bolt": "latest",
     "ai": "latest",
+    "openai": "^4.0.0",
     "zod": "^4.0.17"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       ai:
         specifier: latest
         version: 5.0.22(zod@4.0.17)
+      openai:
+        specifier: ^4.0.0
+        version: 4.104.0(ws@8.18.3)(zod@4.0.17)
       zod:
         specifier: ^4.0.17
         version: 4.0.17
@@ -932,6 +935,12 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
+  '@types/node@18.19.123':
+    resolution: {integrity: sha512-K7DIaHnh0mzVxreCR9qwgNxp3MH9dltPNIEddW9MYUlcKAzm+3grKNSTe2vCJHI1FaLpvpL5JGJrz1UZDKYvDg==}
+
   '@types/node@24.2.1':
     resolution: {integrity: sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==}
 
@@ -1074,6 +1083,10 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
 
   ai@5.0.22:
     resolution: {integrity: sha512-RZiYhj7Ux7hrLtXkHPcxzdiSZt4NOiC69O5AkNfMCsz3twwz/KRkl9ASptosoOsg833s5yRcTSdIu5z53Sl6Pw==}
@@ -1718,9 +1731,16 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  form-data-encoder@1.7.2:
+    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
+
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
+
+  formdata-node@4.4.1:
+    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
+    engines: {node: '>= 12.20'}
 
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
@@ -1848,6 +1868,9 @@ packages:
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -2341,6 +2364,18 @@ packages:
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
+
+  openai@4.104.0:
+    resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   ora@8.2.0:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
@@ -2889,6 +2924,9 @@ packages:
   unctx@2.4.1:
     resolution: {integrity: sha512-AbaYw0Nm4mK4qjhns67C+kgxR2YWiwlDBPzxrN8h8C6VtAdCgditAY5Dezu3IJy4XVqAnbrXt9oQJvsn3fyozg==}
 
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   undici-types@7.10.0:
     resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
 
@@ -3023,6 +3061,10 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  web-streams-polyfill@4.0.0-beta.3:
+    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
+    engines: {node: '>= 14'}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -3877,6 +3919,15 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 24.2.1
+      form-data: 4.0.4
+
+  '@types/node@18.19.123':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@24.2.1':
     dependencies:
       undici-types: 7.10.0
@@ -4063,6 +4114,10 @@ snapshots:
   acorn@8.15.0: {}
 
   agent-base@7.1.4: {}
+
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
 
   ai@5.0.22(zod@4.0.17):
     dependencies:
@@ -4729,6 +4784,8 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  form-data-encoder@1.7.2: {}
+
   form-data@4.0.4:
     dependencies:
       asynckit: 0.4.0
@@ -4736,6 +4793,11 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+
+  formdata-node@4.4.1:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 4.0.0-beta.3
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -4880,6 +4942,10 @@ snapshots:
   httpxy@0.1.7: {}
 
   human-signals@5.0.0: {}
+
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
 
   iconv-lite@0.6.3:
     dependencies:
@@ -5407,6 +5473,21 @@ snapshots:
       define-lazy-prop: 2.0.0
       is-docker: 2.2.1
       is-wsl: 2.2.0
+
+  openai@4.104.0(ws@8.18.3)(zod@4.0.17):
+    dependencies:
+      '@types/node': 18.19.123
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    optionalDependencies:
+      ws: 8.18.3
+      zod: 4.0.17
+    transitivePeerDependencies:
+      - encoding
 
   ora@8.2.0:
     dependencies:
@@ -5996,6 +6077,8 @@ snapshots:
       magic-string: 0.30.17
       unplugin: 2.3.5
 
+  undici-types@5.26.5: {}
+
   undici-types@7.10.0: {}
 
   unenv@2.0.0-rc.19:
@@ -6105,6 +6188,8 @@ snapshots:
   vary@1.1.2: {}
 
   web-streams-polyfill@3.3.3: {}
+
+  web-streams-polyfill@4.0.0-beta.3: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/server/lib/ai/realtime.ts
+++ b/server/lib/ai/realtime.ts
@@ -1,0 +1,44 @@
+interface RealtimeSession {
+  id: string;
+  model: string;
+  expires_at: string;
+  client_secret: {
+    value: string;
+    expires_at: string;
+  };
+}
+
+/**
+ * Create a new OpenAI Realtime session for voice conversations.
+ *
+ * This helper contacts the OpenAI Realtime API and returns an
+ * ephemeral session token that can be used to establish a WebRTC
+ * connection to the model. The token is short lived and should be
+ * used immediately by the client.
+ */
+export const createRealtimeSession = async (): Promise<RealtimeSession> => {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY is not set");
+  }
+
+  const response = await fetch("https://api.openai.com/v1/realtime/sessions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "gpt-4o-realtime-preview-2024-12-17",
+      voice: "alloy",
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to create Realtime session: ${await response.text()}`,
+    );
+  }
+
+  return (await response.json()) as RealtimeSession;
+};

--- a/server/lib/slack/utils.ts
+++ b/server/lib/slack/utils.ts
@@ -121,7 +121,6 @@ export const getChannelContextAsModelMessage = async (
   });
 };
 
-
 export const addReaction = async ({
   channel,
   timestamp,

--- a/server/listeners/commands/index.ts
+++ b/server/listeners/commands/index.ts
@@ -1,8 +1,10 @@
 import type { App } from "@slack/bolt";
 import { sampleCommandCallback } from "./sample-command";
+import { voiceCommandCallback } from "./voice";
 
 const register = (app: App) => {
   app.command("/sample-command", sampleCommandCallback);
+  app.command("/voice", voiceCommandCallback);
 };
 
 export default { register };

--- a/server/listeners/commands/voice.ts
+++ b/server/listeners/commands/voice.ts
@@ -1,0 +1,27 @@
+import type {
+  AllMiddlewareArgs,
+  SlackCommandMiddlewareArgs,
+} from "@slack/bolt";
+
+import { createRealtimeSession } from "~/lib/ai/realtime";
+
+export const voiceCommandCallback = async ({
+  ack,
+  respond,
+  logger,
+}: AllMiddlewareArgs & SlackCommandMiddlewareArgs) => {
+  await ack();
+  try {
+    const session = await createRealtimeSession();
+    await respond({
+      response_type: "ephemeral",
+      text: `Realtime voice session created. Token: \`${session.client_secret.value}\`\nExpires: ${session.client_secret.expires_at}`,
+    });
+  } catch (error) {
+    logger.error("Voice command failed:", error);
+    await respond({
+      response_type: "ephemeral",
+      text: "Failed to create Realtime session.",
+    });
+  }
+};

--- a/server/listeners/events/app-mention.ts
+++ b/server/listeners/events/app-mention.ts
@@ -3,8 +3,8 @@ import type { ModelMessage } from "ai";
 import { respondToMessage } from "~/lib/ai/respond-to-message";
 import {
   getThreadContextAsModelMessage,
-  updateAgentStatus,
   MessageState,
+  updateAgentStatus,
 } from "~/lib/slack/utils";
 
 const appMentionCallback = async ({
@@ -71,7 +71,7 @@ const appMentionCallback = async ({
     });
   } catch (error) {
     logger.error("app_mention handler failed:", error);
-    
+
     // Try to mark message as failed, but don't let this prevent user notification
     try {
       await MessageState.setError({
@@ -81,7 +81,7 @@ const appMentionCallback = async ({
     } catch (reactionError) {
       logger.warn("Failed to set error reaction:", reactionError);
     }
-    
+
     await say({
       text: "Sorry, something went wrong processing your message. Please try again.",
       thread_ts: event.thread_ts || event.ts,


### PR DESCRIPTION
## Summary
- support OpenAI Realtime API for voice by generating ephemeral session tokens
- add `/voice` slash command and manifest entry to request a voice session
- document required `OPENAI_API_KEY` and usage in README

## Testing
- `pnpm install`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68b1c1984038833092f6486c1f1cb67f